### PR TITLE
Fix code blocks format

### DIFF
--- a/ts_runtimes.md
+++ b/ts_runtimes.md
@@ -201,10 +201,10 @@ First, examine the logs for any obvious errors that might cause the Liberty appl
 
 * When you deploy the application by using the `ibmcloud cf push` command, specify a longer application start timeout by using the `-t` option. For example:
 
-        ```
-	ibmcloud cf push myApp -t 180
-        ```
-	{: codeblock}
+    ```
+    ibmcloud cf push myApp -t 180
+    ```
+    {: codeblock}
 
 * The health check timeout can also be specified in the manifest.yml file. For example:
 
@@ -230,10 +230,10 @@ If your application takes a long time to initialize, you might have to re-factor
 
 1. Deploy your application with "--no-route" option. This will disable the port health check. For example:
 
-        ```
-	ibmcloud cf push myApp –no-route
-        ```
-	{: codeblock}
+    ```
+    ibmcloud cf push myApp –no-route
+    ```
+    {: codeblock}
 
 2. Once the application is initialized, map a route to the application. For example:
 


### PR DESCRIPTION
Two of the current code blocks are not rendering properly:
![image](https://user-images.githubusercontent.com/3076261/101439303-dce53680-38d9-11eb-8715-dda77cca1029.png)

and 
![image](https://user-images.githubusercontent.com/3076261/101439315-e2428100-38d9-11eb-9116-b3bfc254fea4.png)
